### PR TITLE
Fix dashboard.js syntax error

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -184,4 +184,5 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-});``
+});
+


### PR DESCRIPTION
## Summary
- remove stray backticks at end of `static/js/dashboard.js`

## Testing
- `python -m py_compile admin.py`
- `node --check static/js/dashboard.js`

------
https://chatgpt.com/codex/tasks/task_e_6854d23436fc83259ba2f8c3501c8e42